### PR TITLE
Adding newline after GPU queue to fix render

### DIFF
--- a/docs/Cluster_queue_information.md
+++ b/docs/Cluster_queue_information.md
@@ -46,6 +46,7 @@ last_modified_date: 09/25/2022 11:18
 |            | arctrdgn001-arctrdgn002     | 5d 8h      | low      | 40   | 192GB  | gpu:V100:4 | N/A                  | suspend    |
 | qTRDGPU    | arctrdagn001-arctrdagn019   | 5d 8h      | N/A      | 64   | 512GB  | gpu:RTX:1  | N/A                  | N/A        |
 |            | arctrdagn031-arctrdagn046   | 5d 8h      | N/A      | 128  | 512GB  | gpu:RTX:2  | N/A                  | N/A        |
+
 ## Special nodes
 
 | Nodes                                        | CPUs | Memory | GPUs      | Purpose                                                                                                                                |


### PR DESCRIPTION
Fix the rendering issue below:
![image](https://github.com/trendscenter/wiki/assets/4120413/f43e534a-0605-4fb9-b3de-bea58c5a4495)

The Markdown syntax is correct and renders correctly in VSCode; however, a newline was missing following the table which maybe caused the render issue on the wiki. 